### PR TITLE
Added Behat step to check for partial/exact error message

### DIFF
--- a/src/TreeHouse/BaseApiBundle/Behat/ApiContext.php
+++ b/src/TreeHouse/BaseApiBundle/Behat/ApiContext.php
@@ -321,12 +321,21 @@ class ApiContext extends BaseFeatureContext
     }
 
     /**
-     * @Then the api error should contain ":text"
+     * @Then the api/API error should contain :text
      */
     public function theApiErrorShouldContain($text)
     {
         $error = $this->getApiError();
-        Assert::assertEquals($text, $error);
+        Assert::assertContains($text, $error);
+    }
+
+    /**
+     * @Then the api/API error should be:
+     */
+    public function theApiErrorShouldEqual(PyStringNode $node)
+    {
+        $error = $this->getApiError();
+        Assert::assertEquals($node->getRaw(), trim($error));
     }
 
     /**


### PR DESCRIPTION
Given the error:

```
This is an error
That spans on multiple lines
```

The following steps are now available:

```gherkin
Then the api error should contain "This is an error"
And the api error should contain "That spans on multiple lines"
```

```gherkin
Then the api error should be:
  """
  This is an error
  That spans on multiple lines
  """
```