### PR TITLE
Clear toegevoegd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
     - php: hhvm
 
 before_install:
-  - echo "memory_limit=1G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - composer self-update
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ php:
   - 7.0
   - hhvm
 
-env:
-  - PREFER_LOWEST="--prefer-lowest"
-  - PREFER_LOWEST=""
-
 matrix:
   fast_finish: true
   include:
@@ -34,7 +30,7 @@ before_install:
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
 
 install:
-  - travis_retry composer install --no-interaction --optimize-autoloader --prefer-dist "$PREFER_LOWEST"
+  - travis_retry composer install --no-interaction --optimize-autoloader --prefer-dist
 
 script:
   - ./vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ matrix:
     - php: hhvm
 
 before_install:
+  - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - composer self-update
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
 
 install:
-  - travis_retry composer update --prefer-dist --no-interaction "$PREFER_LOWEST"
+  - travis_retry composer install --no-interaction --optimize-autoloader --prefer-dist "$PREFER_LOWEST"
 
 script:
   - ./vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ php:
   - 7.0
   - hhvm
 
+env:
+  - PREFER_LOWEST="--prefer-lowest"
+  - PREFER_LOWEST=""
+
 matrix:
   fast_finish: true
   include:
@@ -25,12 +29,12 @@ matrix:
     - php: hhvm
 
 before_install:
-  - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - echo "memory_limit=1G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - composer self-update
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
 
 install:
-  - travis_retry composer install --no-interaction --optimize-autoloader --prefer-dist
+  - travis_retry composer update --prefer-dist --no-interaction "$PREFER_LOWEST"
 
 script:
   - ./vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover

--- a/src/TreeHouse/BaseApiBundle/Behat/BaseFeatureContext.php
+++ b/src/TreeHouse/BaseApiBundle/Behat/BaseFeatureContext.php
@@ -168,6 +168,8 @@ abstract class BaseFeatureContext implements SnippetAcceptingContext, KernelAwar
             $doctrine->persist($entity);
             $doctrine->flush();
         }
+
+        $doctrine->clear();
     }
 
     /**


### PR DESCRIPTION
Clear toegevoegd om te voorkomen dat behat-fixture data direct wordt gebruikt in de applicatie. Door de clear wordt doctrine geforceerd de data op te halen uit de database, zoals de applicatie in het echt ook zou werken.
